### PR TITLE
fix for max = 0 case

### DIFF
--- a/roundProgress.js
+++ b/roundProgress.js
@@ -60,7 +60,7 @@ angular.module('angular-svg-round-progress', [])
                 // credit to http://stackoverflow.com/questions/5736398/how-to-calculate-the-svg-path-for-an-arc-of-a-circle
                 var value       = value >= total ? total - 0.00001 : value,
                     type        = isSemicircle ? 180 : 359.9999,
-                    perc        = (value/total)*type,
+                    perc        = total === 0 ? 0 : (value / total) * type,
                     x           = size/2,
                     start       = polarToCartesian(x, x, R, perc), // in this case x and y are the same
                     end         = polarToCartesian(x, x, R, 0),


### PR DESCRIPTION
Error: Invalid value for <path> attribute d="M NaN NaN A 80 80 0 0 0 84 4" jquery.js:6958

Fix for error caused by having a max value = 0.
there are certain use cases (where the progress bar could start from a 0/0 position.

Added: a simple check to see if total was 0, if so set perc to 0 to avoid divide by 0 error 
(assume that was what was causing the js console to explode with redness)
