### PR TITLE
Correct accessibility values

### DIFF
--- a/src/lib/round-progress/round-progress.component.ts
+++ b/src/lib/round-progress/round-progress.component.ts
@@ -23,8 +23,9 @@ import {RoundProgressEase} from './round-progress.ease';
   styleUrls: ['./round-progress.component.css'],
   host: {
     role: 'progressbar',
-    '[attr.aria-valuemin]': 'current',
+    '[attr.aria-valuemin]': '0',
     '[attr.aria-valuemax]': 'max',
+    '[attr.aria-valuenow]': 'current',
     '[style.width]': 'responsive ? "" : _getDiameter() + "px"',
     '[style.height]': '_getElementHeight()',
     '[style.padding-bottom]': '_getPaddingBottom()',


### PR DESCRIPTION
`aria-valuemin` is not where the current value should go, `aria-valuenow` is. This is causing problems where screen readers are reading out incorrect percentages as negative values. (see https://www.w3.org/TR/wai-aria-1.1/#progressbar for more info)